### PR TITLE
Feat: send extra intent data using bundles

### DIFF
--- a/packages/capacitor-plugin/package.json
+++ b/packages/capacitor-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-android-intents",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Simple intent tools for Capacitor on Android",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Intent data was added to "value" key of the intent, this does not make much sense. This is a breaking change thus the major version bump. 

Old behaviour can be restored by send an intent with ```{"value": {"value": JSON.stringify(obj)}}```